### PR TITLE
feat: Add full API Gateway configuration for RESTful Lambda integration

### DIFF
--- a/.iac/lambda/lambda_delete.mjs
+++ b/.iac/lambda/lambda_delete.mjs
@@ -5,43 +5,31 @@ const client = new DynamoDBClient({});
 const docClient = DynamoDBDocumentClient.from(client);
 
 export const handler = async (event) => {
+  const blog_id = Number(event.pathParameters.blog_id);
+
+  if (!blog_id) {
+    return {
+      statusCode: 400,
+      body: JSON.stringify({ error: "Falta el parámetro blog_id" }),
+    };
+  }
+
   const command = new DeleteCommand({
     TableName: process.env.TABLE_NAME || "blogs-dev",
-    Key: {
-      blog_id : event.blog_id,
-    },
+    Key: { blog_id },
   });
+
   try {
-    const response = await docClient.send(command);
-    console.log(response);
-    return "Successfully deleted item!";
+    await docClient.send(command);
+
+    return {
+      statusCode: 200,
+      body: JSON.stringify({ message: `Blog con ID ${blog_id} eliminado correctamente` }),
+    };
   } catch (err) {
-    return { error: err }
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ error: "Error al eliminar", detalle: err.message }),
+    };
   }
 };
-
-
-
-
-
-// // deleteBlogsLambda
-
-// const AWS = require('aws-sdk');
-// const docClient = new AWS.DynamoDB.DocumentClient();
-
-// var params = {
-//   TableName: process.env.TABLE_NAME || "blogs-dev",
-//   Key: {
-//     "blog_id": 1
-//   },
-//   ReturnValues: "ALL_OLD"
-// }
-
-// exports.handler = async (event, context) => {
-//   try {
-//     const data = await docClient.delete(params).promise()
-//     return { body: JSON.stringify(data) }
-//   } catch (err) {
-//     return { error: err }
-//   }
-// }

--- a/.iac/lambda/lambda_get.mjs
+++ b/.iac/lambda/lambda_get.mjs
@@ -5,14 +5,38 @@ const client = new DynamoDBClient({});
 const docClient = DynamoDBDocumentClient.from(client);
 
 export const handler = async (event) => {
+  const blog_id = Number(event.queryStringParameters?.blog_id);
+
+  if (!blog_id) {
+    return {
+      statusCode: 400,
+      body: JSON.stringify({ error: "Falta el parámetro blog_id" }),
+    };
+  }
+
   const command = new GetCommand({
     TableName: process.env.TABLE_NAME || "blogs-dev",
-    Key: {
-      blog_id : event.blog_id,
-    },
+    Key: { blog_id },
   });
 
-  const response = await docClient.send(command);
-  console.log(response);
-  return response;
+  try {
+    const response = await docClient.send(command);
+
+    if (!response.Item) {
+      return {
+        statusCode: 404,
+        body: JSON.stringify({ error: "Blog no encontrado" }),
+      };
+    }
+
+    return {
+      statusCode: 200,
+      body: JSON.stringify(response.Item),
+    };
+  } catch (err) {
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ error: "Error interno", detalle: err.message }),
+    };
+  }
 };

--- a/.iac/lambda/lambda_post.mjs
+++ b/.iac/lambda/lambda_post.mjs
@@ -5,19 +5,37 @@ const client = new DynamoDBClient({});
 const docClient = DynamoDBDocumentClient.from(client);
 
 export const handler = async (event) => {
-  const command = new PutCommand({
-    TableName: process.env.TABLE_NAME || "blogs-dev",
-    Item: {
-      "blog_id": event.blog_id,
-      "blog_author": event.blog_author,
-      "blog_title": event.blog_title
-    },
-  });
   try {
-    const response = await docClient.send(command);
-    console.log(response);
-    return "Successfully created item!";
+    // Parsear el body JSON
+    const body = JSON.parse(event.body || "{}");
+
+    // Validación mínima
+    if (!body.blog_id || !body.blog_author || !body.blog_title) {
+      return {
+        statusCode: 400,
+        body: JSON.stringify({ error: "Faltan campos obligatorios: blog_id, blog_author, blog_title" }),
+      };
+    }
+
+    const command = new PutCommand({
+      TableName: process.env.TABLE_NAME || "blogs-dev",
+      Item: {
+        blog_id: body.blog_id, // debe ser number si así lo definiste
+        blog_author: body.blog_author,
+        blog_title: body.blog_title
+      },
+    });
+
+    await docClient.send(command);
+
+    return {
+      statusCode: 200,
+      body: JSON.stringify({ message: "Item creado exitosamente" }),
+    };
   } catch (err) {
-    return { error: err }
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ error: err.message }),
+    };
   }
 };

--- a/.iac/main.tf
+++ b/.iac/main.tf
@@ -152,7 +152,7 @@ resource "aws_iam_role_policy_attachment" "delete_logs" {
       # 		}
       # 	]
       # }
-
+# 4. Política para getBlogsLambda (GetItem)
 data "aws_iam_policy_document" "get_policy" {
   statement {
     effect = "Allow"
@@ -193,7 +193,7 @@ data "aws_iam_policy_document" "delete_policy" {
 
 resource "aws_iam_role_policy" "delete_inline_policy" {
   name   = "delete-blogs-inline-policy"
-  role   = aws_iam_role.post_lambda_role.name
+  role   = aws_iam_role.delete_lambda_role.name
   policy = data.aws_iam_policy_document.delete_policy.json
 }
 
@@ -249,7 +249,7 @@ resource "aws_lambda_function" "delete" {
   function_name = "deleteBlogsLambda"
   filename      = data.archive_file.delete_lambda.output_path
   handler       = "lambda_delete.handler"
-  runtime       = "nodejs18.x"
+  runtime       = "nodejs22.x"
   role          = aws_iam_role.delete_lambda_role.arn
   environment {
     variables = {
@@ -258,100 +258,135 @@ resource "aws_lambda_function" "delete" {
   }
 }
 
-# // 4. API Gateway REST
-# resource "aws_api_gateway_rest_api" "blog_api" {
-#   name        = "blog-api"
-#   description = "Serverless Blog API"
-# }
+// 4. API Gateway REST - Crea la instancia del API REST.
+ #  Es la raíz del API, sobre ella se montarán los recursos como /blogs, /blogs/{blog_id}, etc.
+resource "aws_api_gateway_rest_api" "blog_api" {
+  name        = "blog-api"
+  description = "Serverless Blog API"
+}
 
-# # Root /blogs
-# resource "aws_api_gateway_resource" "blogs" {
-#   rest_api_id = aws_api_gateway_rest_api.blog_api.id
-#   parent_id   = aws_api_gateway_rest_api.blog_api.root_resource_id
-#   path_part   = "blogs"
-# }
+# Root /blogs - Esto crea el path /blogs dentro de tu API
+resource "aws_api_gateway_resource" "blogs" {
+  rest_api_id = aws_api_gateway_rest_api.blog_api.id
+  parent_id   = aws_api_gateway_rest_api.blog_api.root_resource_id  # apunta a la raíz
+  path_part   = "blogs"
+}
 
-# // 4.1 Método GET /blogs
-# resource "aws_api_gateway_method" "get_blogs" {
-#   rest_api_id   = aws_api_gateway_rest_api.blog_api.id
-#   resource_id   = aws_api_gateway_resource.blogs.id
-#   http_method   = "GET"
-#   authorization = "NONE"
-# }
+// 4.1 Método GET /blogs - Permite invocar GET /blogs sin autenticación
+resource "aws_api_gateway_method" "get_blogs" {
+  rest_api_id   = aws_api_gateway_rest_api.blog_api.id
+  resource_id   = aws_api_gateway_resource.blogs.id
+  http_method   = "GET"
+  authorization = "NONE"
+}
 
-# resource "aws_api_gateway_integration" "get_blogs" {
-#   rest_api_id             = aws_api_gateway_rest_api.blog_api.id
-#   resource_id             = aws_api_gateway_resource.blogs.id
-#   http_method             = aws_api_gateway_method.get_blogs.http_method
-#   integration_http_method = "POST"
-#   type                    = "AWS_PROXY"
-#   uri                     = aws_lambda_function.get.invoke_arn
-# }
+# Integración GET con Lambda - Aquí se conecta la ruta /blogs al Lambda get
+resource "aws_api_gateway_integration" "get_blogs" {
+  rest_api_id             = aws_api_gateway_rest_api.blog_api.id
+  resource_id             = aws_api_gateway_resource.blogs.id
+  http_method             = aws_api_gateway_method.get_blogs.http_method
+  integration_http_method = "POST"
+  type                    = "AWS_PROXY" # Modo AWS_PROXY, es decir, pasa todo el request tal cual al Lambda
+  uri                     = aws_lambda_function.get.invoke_arn
+}
 
-# // 4.2 Método POST /blogs
-# resource "aws_api_gateway_method" "post_blogs" {
-#   rest_api_id   = aws_api_gateway_rest_api.blog_api.id
-#   resource_id   = aws_api_gateway_resource.blogs.id
-#   http_method   = "POST"
-#   authorization = "NONE"
-# }
+// 4.2 Método POST /blogs 
+resource "aws_api_gateway_method" "post_blogs" {
+  rest_api_id   = aws_api_gateway_rest_api.blog_api.id
+  resource_id   = aws_api_gateway_resource.blogs.id
+  http_method   = "POST"
+  authorization = "NONE"
+}
 
-# resource "aws_api_gateway_integration" "post_blogs" {
-#   rest_api_id             = aws_api_gateway_rest_api.blog_api.id
-#   resource_id             = aws_api_gateway_resource.blogs.id
-#   http_method             = aws_api_gateway_method.post_blogs.http_method
-#   integration_http_method = "POST"
-#   type                    = "AWS_PROXY"
-#   uri                     = aws_lambda_function.post.invoke_arn
-# }
+# Integración POST con Lambda - Aquí se conecta la ruta /blogs al Lambda post
+resource "aws_api_gateway_integration" "post_blogs" {
+  rest_api_id             = aws_api_gateway_rest_api.blog_api.id
+  resource_id             = aws_api_gateway_resource.blogs.id
+  http_method             = aws_api_gateway_method.post_blogs.http_method
+  integration_http_method = "POST"
+  type                    = "AWS_PROXY"
+  uri                     = aws_lambda_function.post.invoke_arn
+}
 
-# # Sub-resource /blogs/{blog_id}
-# resource "aws_api_gateway_resource" "blog_item" {
-#   rest_api_id = aws_api_gateway_rest_api.blog_api.id
-#   parent_id   = aws_api_gateway_resource.blogs.id
-#   path_part   = "{blog_id}"
-# }
+# Sub-resource /blogs/{blog_id} - Crea el path dinámico con parámetro de ruta.
+resource "aws_api_gateway_resource" "blog_item" {
+  rest_api_id = aws_api_gateway_rest_api.blog_api.id
+  parent_id   = aws_api_gateway_resource.blogs.id
+  path_part   = "{blog_id}"
+}
 
-# // 4.3 Método DELETE /blogs/{blog_id}
-# resource "aws_api_gateway_method" "delete_blog" {
-#   rest_api_id   = aws_api_gateway_rest_api.blog_api.id
-#   resource_id   = aws_api_gateway_resource.blog_item.id
-#   http_method   = "DELETE"
-#   authorization = "NONE"
-#   request_parameters = {
-#     "method.request.path.blog_id" = true
-#   }
-# }
+// 4.3 Método DELETE /blogs/{blog_id} - Requiere el parámetro blog_id en la URL
+resource "aws_api_gateway_method" "delete_blog" {
+  rest_api_id   = aws_api_gateway_rest_api.blog_api.id
+  resource_id   = aws_api_gateway_resource.blog_item.id
+  http_method   = "DELETE"
+  authorization = "NONE"
+  request_parameters = {
+    "method.request.path.blog_id" = true
+  }
+}
 
-# resource "aws_api_gateway_integration" "delete_blog" {
-#   rest_api_id             = aws_api_gateway_rest_api.blog_api.id
-#   resource_id             = aws_api_gateway_resource.blog_item.id
-#   http_method             = aws_api_gateway_method.delete_blog.http_method
-#   integration_http_method = "POST"
-#   type                    = "AWS_PROXY"
-#   uri                     = aws_lambda_function.delete.invoke_arn
-#   request_parameters = {
-#     "integration.request.path.blog_id" = "method.request.path.blog_id"
-#   }
-# }
+resource "aws_api_gateway_integration" "delete_blog" {
+  rest_api_id             = aws_api_gateway_rest_api.blog_api.id
+  resource_id             = aws_api_gateway_resource.blog_item.id
+  http_method             = aws_api_gateway_method.delete_blog.http_method
+  integration_http_method = "POST"
+  type                    = "AWS_PROXY"
+  uri                     = aws_lambda_function.delete.invoke_arn
+  request_parameters = {
+    "integration.request.path.blog_id" = "method.request.path.blog_id"
+  }
+}
 
-# // 5. Integración Lambda proxy
-# resource "aws_api_gateway_deployment" "deployment" {
-#   rest_api_id = aws_api_gateway_rest_api.blog_api.id
-#   depends_on = [
-#     aws_api_gateway_integration.get_blogs,
-#     aws_api_gateway_integration.post_blogs,
-#     aws_api_gateway_integration.delete_blog
-#   ]
-#   lifecycle {
-#     create_before_destroy = true
-#   }
-# }
+resource "aws_lambda_permission" "apigw_lambda_get" {
+  statement_id  = "InvokePermissionFromApiGatewayGetBlogsTerraform"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.get.function_name
+  principal     = "apigateway.amazonaws.com"
 
-# // 4.5 Despliegue y stage
-# resource "aws_api_gateway_stage" "dev" {
-#   rest_api_id      = aws_api_gateway_rest_api.blog_api.id
-#   deployment_id    = aws_api_gateway_deployment.deployment.id
-#   stage_name       = "dev"
-#   description      = "Development stage"
-# }
+  # More: http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-control-access-using-iam-policies-to-invoke-api.html
+  //source_arn = "arn:aws:execute-api:us-east-2:465731220541:rddszkmn2k/*/GET/blogs"
+  source_arn    = "arn:aws:execute-api:${var.myregion}:${var.accountId}:${aws_api_gateway_rest_api.blog_api.id}/*/${aws_api_gateway_method.get_blogs.http_method}${aws_api_gateway_resource.blogs.path}"
+}
+
+resource "aws_lambda_permission" "apigw_lambda_post" {
+  statement_id  = "InvokePermissionFromApiGatewayPostBlogsTerraform"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.post.function_name
+  principal     = "apigateway.amazonaws.com"
+  //source_arn    = "arn:aws:execute-api:us-east-2:465731220541:rddszkmn2k/*/POST/blogs"
+  source_arn    = "arn:aws:execute-api:${var.myregion}:${var.accountId}:${aws_api_gateway_rest_api.blog_api.id}/*/${aws_api_gateway_method.post_blogs.http_method}${aws_api_gateway_resource.blogs.path}"
+}
+
+resource "aws_lambda_permission" "apigw_lambda_delete" {
+  statement_id  = "InvokePermissionFromApiGatewayDeleteBlogsTerraform"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.delete.function_name
+  principal     = "apigateway.amazonaws.com"
+  //source_arn    = "arn:aws:execute-api:us-east-2:465731220541:rddszkmn2k/*/DELETE/blogs/*"  # El * al final de blogs/* es importante porque blog_id es dinámico (path parameter)
+  source_arn    = "arn:aws:execute-api:${var.myregion}:${var.accountId}:${aws_api_gateway_rest_api.blog_api.id}/*/${aws_api_gateway_method.delete_blog.http_method}${aws_api_gateway_resource.blog_item.path}"
+}
+
+
+// 5. Integración Lambda proxy
+resource "aws_api_gateway_deployment" "deployment" {
+  rest_api_id = aws_api_gateway_rest_api.blog_api.id
+  depends_on = [
+    aws_api_gateway_integration.get_blogs,
+    aws_api_gateway_integration.post_blogs,
+    aws_api_gateway_integration.delete_blog
+  ]
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+// 4.5 Despliegue y stage
+resource "aws_api_gateway_stage" "dev" {
+  rest_api_id      = aws_api_gateway_rest_api.blog_api.id
+  deployment_id    = aws_api_gateway_deployment.deployment.id
+  stage_name       = "dev"
+  description      = "Development stage"
+}
+# Esto publica todos los endpoints bajo una URL final del tipo:
+  # https://{rest_api_id}.execute-api.us-east-2.amazonaws.com/dev/blogs

--- a/.iac/variables.tf
+++ b/.iac/variables.tf
@@ -9,3 +9,11 @@
 #   type        = string
 #   default     = "messagesApp"
 # }
+
+variable "myregion" {
+  default = "us-east-2"
+}
+
+variable "accountId" {
+  description = "AWS account ID"
+}


### PR DESCRIPTION
- Defined REST API using aws_api_gateway_rest_api for root API creation.
- Created resources for /blogs and /blogs/{blog_id} endpoints.
- Added GET, POST, and DELETE methods with AWS_PROXY integrations for each Lambda.
- Set up Lambda permissions using dynamic ARN generation (no hardcoded source_arn).
- Deployed API Gateway using aws_api_gateway_deployment and aws_api_gateway_stage.
- Added Terraform variables for region and account ID.